### PR TITLE
Fixing Typos in CSELS and DPHID

### DIFF
--- a/StdTxGuide/StdTxGuide/content/about_us.html
+++ b/StdTxGuide/StdTxGuide/content/about_us.html
@@ -25,7 +25,7 @@
 
 <p>The STD Treatment (Tx) Guidelines mobile app serves as a quick reference guide for doctors and related parties on the identification of and treatment for sexually transmitted diseases (STDs).
 </p>
-<p>The app is a collaboration between CDC's Division of STD Prevention and the Informatics Innovation Unit (IIU) within CDC's Division of Information Dissemination - Center for Epidemiology, Surveillance, and Laboratory Services. The information in this mobile application is based on the CDC’s 2015 Sexually Transmitted Diseases Treatment Guidelines and the 2012 MMWR Update to CDC's Sexually Transmitted Diseases Treatment Guidelines, 2010: Oral Cephalosporins No Longer a Recommended Treatment for Gonococcal Infections (MMWR 2012; 61 (31): 590-594).
+<p>The app is a collaboration between CDC's Division of STD Prevention and the Informatics Innovation Unit (IIU) within CDC's Division of Public Health Information Dissemination - Center for Surveillance, Epidemiology and Laboratory Services. The information in this mobile application is based on the CDC’s 2015 Sexually Transmitted Diseases Treatment Guidelines and the 2012 MMWR Update to CDC's Sexually Transmitted Diseases Treatment Guidelines, 2010: Oral Cephalosporins No Longer a Recommended Treatment for Gonococcal Infections (MMWR 2012; 61 (31): 590-594).
 </p>
 <p>For comments and feedback, please email <a href="mailto:etools@cdc.gov">etools@cdc.gov</a>.
 </p>


### PR DESCRIPTION
The DIvision of Public Health Information Dissemination was missing the "public health" part. CSELS was spelled out as CESLS.